### PR TITLE
Add email configuration to DB-Auth stack

### DIFF
--- a/initial-configuration/config/wildfly/emailTemplates/accessEmail.mustache
+++ b/initial-configuration/config/wildfly/emailTemplates/accessEmail.mustache
@@ -1,0 +1,17 @@
+Access Changed:
+
+{{#rolesExists}}
+You have been granted access to {{systemName}} with the following roles:
+{{/rolesExists}}
+{{#roles}}
+{{name}} : {{#privileges}} {{description}} {{/privileges}}
+{{/roles}}
+{{^roles}}
+Currently NO roles have been granted for you to {{systemName}}.
+{{/roles}}
+ {{#documentation}}
+You can find documentation at the following links:
+ {{.}}
+{{/documentation}}
+
+Have a good day!

--- a/initial-configuration/config/wildfly/emailTemplates/accessEmail.mustache
+++ b/initial-configuration/config/wildfly/emailTemplates/accessEmail.mustache
@@ -1,5 +1,8 @@
 Access Changed:
 
+Your user name is {{username}}
+Your generated password is {{initialPassword}} You will need to change this the first time you log into the system.
+
 {{#rolesExists}}
 You have been granted access to {{systemName}} with the following roles:
 {{/rolesExists}}

--- a/initial-configuration/config/wildfly/emailTemplates/deniedAccessEmail.mustache
+++ b/initial-configuration/config/wildfly/emailTemplates/deniedAccessEmail.mustache
@@ -1,0 +1,6 @@
+The following user has been denied access to the {{systemName}} environment because their user has not been configured.
+
+First Name : {{given_name}}
+Last Name : {{family_name}}
+Email : {{email}}
+ID : {{nickname}}

--- a/initial-configuration/config/wildfly/standalone.xml
+++ b/initial-configuration/config/wildfly/standalone.xml
@@ -473,10 +473,10 @@
                 <simple name="java:global/clientSecretIsBase64" value="False"/>
                 <simple name="java:global/userActivationTemplatePath" value="/psama/activation"/>
                 <simple name="java:global/userActivationReplyTo" value="__USER_ACTIVATION_REPLY_TO__"/>
-                <simple name="java:global/templatePath" value="/usr/local/docker-config/templates/" />
+                <simple name="java:global/templatePath" value="/opt/jboss/wildfly/standalone/configuration/emailTemplates/" />
                 <simple name="java:global/tosEnabled" value="False" />
                 <simple name="java:global/auth0host" value="https://__AUTH0_DOMAIN__.auth0.com/" />
-                <simple name="java:global/emailTemplatePath" value="/usr/local/docker-config/wildfly/emailTemplates/" />
+                <simple name="java:global/emailTemplatePath" value="/opt/jboss/wildfly/standalone/configuration/emailTemplates/" />
                 <simple name="java:global/accessGrantEmailSubject" value="__ACCESS_GRANTED_EMAIL_SUBJECT__" />
                 <simple name="java:global/deniedEmailEnabled" value="false" />
                 <simple name="java:global/adminUsers" value="__ADMIN_USERS__" />

--- a/initial-configuration/config/wildfly/standalone.xml
+++ b/initial-configuration/config/wildfly/standalone.xml
@@ -473,10 +473,10 @@
                 <simple name="java:global/clientSecretIsBase64" value="False"/>
                 <simple name="java:global/userActivationTemplatePath" value="/psama/activation"/>
                 <simple name="java:global/userActivationReplyTo" value="__USER_ACTIVATION_REPLY_TO__"/>
-                <simple name="java:global/templatePath" value="/usr/local/docker-config/templates" />
+                <simple name="java:global/templatePath" value="/usr/local/docker-config/templates/" />
                 <simple name="java:global/tosEnabled" value="False" />
                 <simple name="java:global/auth0host" value="https://__AUTH0_DOMAIN__.auth0.com/" />
-                <simple name="java:global/emailTemplatePath" value="/usr/local/docker-config/templates" />
+                <simple name="java:global/emailTemplatePath" value="/usr/local/docker-config/wildfly/emailTemplates/" />
                 <simple name="java:global/accessGrantEmailSubject" value="__ACCESS_GRANTED_EMAIL_SUBJECT__" />
                 <simple name="java:global/deniedEmailEnabled" value="false" />
                 <simple name="java:global/adminUsers" value="__ADMIN_USERS__" />

--- a/initial-configuration/config/wildfly/standalone.xml
+++ b/initial-configuration/config/wildfly/standalone.xml
@@ -450,10 +450,8 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:jsf:1.1"/>
         <subsystem xmlns="urn:jboss:domain:mail:3.0">
-            <mail-session name="java:jboss/mail/gmail" from="${env.EMAIL_USERNAME_FROM:emailFromName}" jndi-name="java:jboss/mail/gmail" debug="false">
-                <smtp-server outbound-socket-binding-ref="mail-smtp-gmail" tls="true"
-									username="${env.EMAIL_USERNAME:missingEmailUsername}"
-										password="${env.EMAIL_PASSWORD:missingEmailPassword}" />
+            <mail-session name="java:jboss/mail/gmail" from="__EMAIL_FROM_ADDR__" jndi-name="java:jboss/mail/gmail" debug="false">
+                <smtp-server outbound-socket-binding-ref="mail-smtp-gmail" tls="true" username="__EMAIL_USER__" password="__EMAIL_PASSWORD__" />
             </mail-session>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:naming:2.0">

--- a/initial-configuration/jenkins/jenkins-docker/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/config.xml
@@ -100,6 +100,7 @@
       <jobNames>
         <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
         <string>Configure Auth0 Integration</string>
+	<string>Configure Outbound Email Settings</string>
         <string>Configure PIC-SURE Token Introspection Token</string>
         <string>Configure SSL Certificates</string>
         <string>Create Admin User</string>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Configure Outbound Email Settings/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Configure Outbound Email Settings/config.xml
@@ -1,0 +1,50 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>GMAIL_USER</name>
+          <description>The user account of an smtp service (default gmail) to use for sending mail</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+	<hudson.model.StringParameterDefinition>
+          <name>GMAIL_FROM</name>
+          <description>The name that should be displayed as the outbound account</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>GMAIL_PASSWORD</name>
+          <description>Password for the gmail account used to send mail</description>
+          <defaultValue>changeme</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>export oldpassword=`cat /usr/local/docker-config/wildfly/standalone.xml | grep smtp-server | grep mail-smtp-gmail | grep -oP &apos;password(\S)*&apos; | cut -d \&quot; -f 2`
+		export olduser=`cat /usr/local/docker-config/wildfly/standalone.xml | grep smtp-server | grep mail-smtp-gmail | grep -oP &apos;username(\S)*&apos; | cut -d \&quot; -f 2`
+		export oldfrom=`cat /usr/local/docker-config/wildfly/standalone.xml | grep mail-session | grep &apos;jboss/mail/gmail&apos; | grep -oP &apos;from(\S)*&apos; | cut -d \&quot; -f 2`
+
+sed -i &quot;s/$oldpassword/$GMAIL_PASSWORD/g&quot; /usr/local/docker-config/wildfly/standalone.xml
+sed -i &quot;s/$olduser/$GMAIL_USER/g&quot; /usr/local/docker-config/wildfly/standalone.xml
+sed -i &quot;s/$oldfrom/$GMAIL_FROM/g&quot; /usr/local/docker-config/wildfly/standalone.xml
+
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Initial Configuration Pipeline/config.xml
@@ -33,6 +33,18 @@
           <defaultValue></defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>GMAIL_USER</name>
+          <description>The gmail account name that should be used to send outbound email.  This field is optional</description>
+          <defaultValue>user@email.com</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>GMAIL_PASSWORD</name>
+          <description>The password for the gmail user.  This field is optional</description>
+          <defaultValue>changeit</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -67,6 +79,15 @@ pipeline {
                     picsureBuild: {
                         script {
                             def result = build job: &apos;PIC-SURE Pipeline&apos;
+                        }
+                    },
+		    emailConfig: {
+                        script {
+                            def result = build job: &apos;Configure Outbound Email Settings&apos;, parameters: [
+                                [$class: &apos;StringParameterValue&apos;, name: &apos;GMAIL_USER&apos;, value:env.GMAIL_USER],
+                                [$class: &apos;StringParameterValue&apos;, name: &apos;GMAIL_FROM&apos;, value: env.GMAIL_USER],
+                                [$class: &apos;StringParameterValue&apos;, name: &apos;GMAIL_PASSWORD&apos;, value: env.GMAIL_PASSWORD]]
+
                         }
                     }
                 )

--- a/initial-configuration/jenkins/jenkins-docker/jobs/Start PIC-SURE/config.xml
+++ b/initial-configuration/jenkins/jenkins-docker/jobs/Start PIC-SURE/config.xml
@@ -38,6 +38,7 @@ WILDFLY_JAVA_OPTS=&quot;-Xms2g -Xmx4g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize
 docker run --name=wildfly --restart always --network=picsure -u root \
 -v /var/log/wildfly-docker-logs/:/opt/jboss/wildfly/standalone/log/ \
 -v /usr/local/docker-config/wildfly/standalone.xml:/opt/jboss/wildfly/standalone/configuration/standalone.xml \
+-v /usr/local/docker-config/wildfly/emailTemplates:/opt/jboss/wildfly/standalone/configuration/emailTemplates \
 -v /usr/local/docker-config/wildfly/wildfly_mysql_module.xml:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/module.xml  \
 -v /usr/local/docker-config/wildfly/mysql-connector-java-5.1.38.jar:/opt/jboss/wildfly/modules/system/layers/base/com/sql/mysql/main/mysql-connector-java-5.1.38.jar \
 -v /var/log/wildfly-docker-os-logs/:/var/log/ \


### PR DESCRIPTION
turns out the email templates were missing from the initial config as well.